### PR TITLE
Fix Issue #4 - query not passed to request.

### DIFF
--- a/lib/mws.js
+++ b/lib/mws.js
@@ -83,7 +83,7 @@ AmazonMwsClient.prototype.call = function(api, action, query) {
 	if (!api.upload) {
 		requestOpts.form = query;
 	} else {
-		request.qs = query;
+		requestOpts.qs = query;
 	}
 
 	return new Promise(function(resolve, reject) {


### PR DESCRIPTION
When using "MWS.Feeds.requests.SubmitFeed()" (!api.upload) is false so the code is sending qs through "request.qs = query". The query parameters are not making it to Request. It works if you use requestOpts.qs = query.