### PR TITLE
Fix for Issue #5: query._FORMAT_ = undefined

### DIFF
--- a/lib/mws.js
+++ b/lib/mws.js
@@ -54,6 +54,7 @@ AmazonMwsClient.prototype.call = function(api, action, query) {
 	// Check if we're dealing with a file (such as a feed) upload
 	if (api.upload) {
 		requestOpts.body = query._BODY_;
+		query._FORMAT_ = 'application/x-www-form-urlencoded';
 		requestOpts.headers = {
 			'Content-Type': query._FORMAT_,
 			'Content-MD5': crypto.createHash('md5').update(query._BODY_).digest('base64')


### PR DESCRIPTION
When using "SubmitFeed()" to send xml in Body:
query.FORMAT is undefined so there is no Content-Type.