### PR TITLE
remove DisplayableOrder prefix. fails on submit to mws

### DIFF
--- a/lib/fba.js
+++ b/lib/fba.js
@@ -184,7 +184,7 @@ var calls = exports.requests = {
             return new FbaInboundRequest('ListInboundShipmentItems', {
                 ShipmentId: { name: 'ShipmentId', required: true },
                 LastUpdatedAfter: { name: 'LastUpdatedAfter', type: 'Timestamp' },
-                LastUpdatedAfter: { name: 'LastUpdatedBefore', type: 'Timestamp' }
+                LastUpdatedBefore: { name: 'LastUpdatedBefore', type: 'Timestamp' }
             });
         },
 
@@ -270,9 +270,9 @@ var calls = exports.requests = {
             return new FbaOutboundRequest('CreateFulfillmentOrder', {
                 SellerFulfillmentOrderId: { name: 'SellerFulfillmentOrderId', required: true },
                 ShippingSpeedCategory: { name: 'ShippingSpeedCategory', required: true, type: 'fba.ShippingSpeedCategory' },
-                DisplayableOrderId: { name: 'DisplayableOrder.DisplayableOrderId', required: true },
-                DisplayableOrderDateTime: { name: 'DisplayableOrder.DisplayableOrderDateTime', type: 'Timestamp' },
-                DisplayableOrderComment: { name: 'DisplayableOrder.DisplayableOrderComment' },
+                DisplayableOrderId: { name: 'DisplayableOrderId', required: true },
+                DisplayableOrderDateTime: { name: 'DisplayableOrderDateTime', type: 'Timestamp' },
+                DisplayableOrderComment: { name: 'DisplayableOrderComment' },
                 FulfillmentPolicy: { name: 'FulfillmentPolicy', required: false, type: 'fba.FulfillmentPolicy' },
                 FulfillmentMethod: { name: 'FulfillmentMethod', required: false },
                 NotificationEmails: { name: 'NotificationEmailList.member', required: false, list: true },


### PR DESCRIPTION
Hi @vedmalex, could you let me know if you'll merge this. I'm using your npm package and would rather not create a new one just for this.

The error mws returns if you submit as it is now is below. Submits OK after my PR.

<ErrorResponse xmlns=\"http://mws.amazonaws.com/FulfillmentOutboundShipment/2010-10-01/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>InvalidRequestException</Code>\n    <Message>The request must contain the parameter DisplayableOrderComment.</Message>\n  </Error>\n  <RequestId>3407b167-9fba-4b0e-899c-1369e633492d</RequestId>\n</ErrorResponse>\n"