### PR TITLE
Add more tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules
+env.sh

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tests
   npm test
   ```
 2. To see more logs while running tests, choose from:
+
   ```
   NODE_DEBUG=request npm test
   NODE_ENV=development npm test

--- a/README.md
+++ b/README.md
@@ -77,3 +77,20 @@ getListOrders(client, {
   console.log("--------");
 });
 ```
+
+Tests
+-----
+
+1. Fill in the values for `env.sh` and run tests:
+
+  ```
+  cd cloneOfThisProject
+  . ./env.sh
+  npm test
+  ```
+2. To see more logs while running tests, choose from:
+  ```
+  NODE_DEBUG=request npm test
+  NODE_ENV=development npm test
+  NODE_ENV=development NODE_DEBUG=request npm test
+  ```

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,16 @@
+## to run from parent level directory
+# $ . ./env.sh
+## to run from within a child project directory
+# $ . ./../env.sh
+## to test if it worked
+# $ echo $MerchantId && echo $AccessKey && echo $MarketPlaceId && echo $SecretKey
+
+#synonym for SellerId
+export MerchantId=
+
+#synonym for AWSAccessKeyId
+export AccessKey=
+
+export MarketPlaceId=
+
+export SecretKey=

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "xml2js": "^0.4.12",
+    "bluebird": "3.4.1",
     "underscore": "^1.8.3",
     "request": "^2.60.0"
   },

--- a/test/products.js
+++ b/test/products.js
@@ -1,0 +1,57 @@
+/**
+ * Various ways to run the test from CLI:
+ *   npm test
+ *   NODE_DEBUG=request npm test
+ *   NODE_ENV=development npm test
+ *   NODE_ENV=development NODE_DEBUG=request npm test
+ */
+
+var MWS = require('../');
+var env = process.env;
+
+const chai = require('chai');
+const expect = chai.expect;
+
+global.Promise = require('bluebird');
+
+describe('Products', function() {
+  var MarketPlaceId = env.MarketPlaceId;
+
+  var client;
+  it('should set up client', function() {
+    expect(env.AccessKey).to.exist;
+    expect(env.SecretKey).to.exist;
+    expect(env.MerchantId).to.exist;
+    expect(env.MarketPlaceId).to.exist;
+
+    expect(env.AccessKey).to.be.a('string');
+    expect(env.SecretKey).to.be.a('string');
+    expect(env.MerchantId).to.be.a('string');
+    expect(env.MarketPlaceId).to.be.a('string');
+
+    console.log(env.AccessKey + '\n' +
+      env.SecretKey + '\n' +
+      env.MerchantId + '\n' +
+      env.MarketPlaceId);
+
+    client = new MWS.Client(env.AccessKey, env.SecretKey, env.MerchantId, {
+      host: 'mws.amazonservices.in'
+    });
+  });
+
+  it('list matching product', function (done) {
+    var listMatchingProducts = MWS.Products.requests.ListMatchingProducts({ "marketplaceId": MarketPlaceId });
+    console.log('listMatchingProducts:', listMatchingProducts);
+    listMatchingProducts.params.MarketplaceId.value = MarketPlaceId;
+    listMatchingProducts.params.Query.value = "shoe leather casual";
+    client.invoke(listMatchingProducts)
+      .then(function (resp) {
+        //console.log(resp);
+        console.log(JSON.stringify(arguments,null,2));
+        var products = resp.ListMatchingProductsResponse.ListMatchingProductsResult[0].Products[0].Product;
+        console.log('products.length:' , products.length);
+        done();
+      });
+  });
+
+});


### PR DESCRIPTION
I began my attempt to understand this library by using tests. During this brief effort, I was able to abstract the setup into `env.sh` file and use a promises library to demo usage of one product api endpoint.

I want to contribute this back in hopes that it will help others and perhaps even lead to more test related contributions.

For example, one key behavior that I learned about this library was that it does not return an `ErrorResponse` from amazon via `reject`! It is debatable whether that is desirable or not ... but it definitely becomes easier to spot and accept as the current behaviour when tests fail.