### PR TITLE
Removed debugging output

### DIFF
--- a/lib/mws.js
+++ b/lib/mws.js
@@ -209,7 +209,6 @@ AmazonMwsRequest.prototype.set = function(param, value) {
 
 		// Handles the actual setting based on type
 		var setValue = function setValue(name, val) {
-			console.log(name, val)
 			if (p.type == 'Timestamp') {
 				self.params[name].value = val.toISOString();
 			} else if (p.type == 'Boolean') {


### PR DESCRIPTION
This creates output in the console window every time a request is created that requires the MarketplaceId - however I'm sure this function is used elsewhere and other output can be seen on other variables.