### PR TITLE
Included AuthToken option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ Initialize
 
 ```javascript
 var MWS = require('mws-sdk-promises'),
-    client = new MWS.Client('accessKeyId', 'secretAccessKey', 'merchantId', {}),
+    client = new MWS.Client(
+      'accessKeyId',
+      'secretAccessKey',
+      'merchantId',
+      {
+        // Optional Auth Token when using delegated Developer access.
+        authToken: 'amzn.mws...'
+      }
+    ),
     MarketplaceId = "ATVPDKIKX0DER";
 ```
 


### PR DESCRIPTION
Auth Token is required when using delegated developer access. Added example to README.md.