### PR TITLE
Add Finances API support

### DIFF
--- a/lib/finances.js
+++ b/lib/finances.js
@@ -1,0 +1,116 @@
+/**
+ * Orders API requests and definitions for Amazon's MWS web services.
+ * For information on using, please see examples folder.
+ *
+ * @author Kevin Dolan
+ */
+var mws = require('./mws');
+
+/**
+ * Construct an Orders API request for mws.Client.invoke()
+ *
+ * @param {String} action Action parameter of request
+ * @param {Object} params Schemas for all supported parameters
+ */
+function FinancesRequest(action, params) {
+    var opts = {
+        name: 'Finances',
+        group: 'Finances Retrieval',
+        path: '/Finances/2015-05-01',
+        version: '2015-05-01',
+        legacy: false,
+        action: action,
+        params: params
+    };
+    return new mws.Request(opts);
+}
+
+/**
+ * Ojects to represent enum collections used by some request(s)
+ * @type {Object}
+ */
+var enums = exports.enums = {
+
+    FulfillmentChannels:  function() {
+        return new mws.Enum(['AFN', 'MFN']);
+    },
+
+    OrderStatuses:  function() {
+        return new mws.Enum(['Pending', 'Unshipped', 'PartiallyShipped', 'Shipped', 'Canceled', 'Unfulfillable']);
+    },
+
+    PaymentMethods:  function() {
+        return new mws.Enum(['COD', 'CVS', 'Other']);
+    }
+
+};
+
+/**
+ * Contains brief definitions for unique data type values.
+ * Can be used to explain input/output to users via tooltips, for example
+ * @type {Object}
+ */
+var types = exports.types = {
+    ServiceStatus: {
+        'GREEN':'The service is operating normally.',
+        'GREEN_I':'The service is operating normally + additional info provided',
+        'YELLOW':'The service is experiencing higher than normal error rates or degraded performance.',
+        'RED':'The service is unabailable or experiencing extremely high error rates.' }
+};
+
+/**
+ * A collection of currently supported request constructors. Once created and
+ * configured, the returned requests can be passed to an mws client `invoke` call
+ * @type {Object}
+ */
+var calls = exports.requests = {
+
+    /**
+     * Requests the operational status of the Orders API section.
+     */
+    GetServiceStatus: function() {
+        return new FinancesRequest('GetServiceStatus', {});
+    },
+
+    /**
+     * Returns financial created or updated during a time frame you specify or by order or groupId.
+     */
+    ListFinancialEvents: function() {
+        return new FinancesRequest('ListFinancialEvents', {
+            PostedAfter: { name: 'PostedAfter', type: 'Timestamp' },
+            PostedBefore: { name: 'PostedBefore', type: 'Timestamp' },
+            FinancialEventGroupId: { name: 'FinancialEventGroupId' },
+            AmazonOrderId: {name: 'AmazonOrderId'},
+            MaxResultsPerPage: { name: 'MaxResultsPerPage' }
+        });
+    },
+
+    /**
+     * Returns the next page of events using the NextToken parameter.
+     */
+    ListFinancialEventsByNextToken: function() {
+        return new FinancesRequest('ListFinancialEventsByNextToken', {
+            NextToken: { name: 'NextToken', required: true }
+        });
+    },
+
+    /**
+     * Returns financial event groups
+     */
+    ListFinancialEventGroups: function() {
+        return new FinancesRequest('ListFinancialEventGroups', {
+            StartedAfter: { name: 'FinancialEventGroupStartedAfter', type: 'Timestamp', required: true },
+            StartedBefore: { name: 'FinancialEventGroupStartedBefore', type: 'Timestamp' },
+            MaxResultsPerPage: { name: 'MaxResultsPerPage' }
+        });
+    },
+
+    /**
+     * Returns the next page of groups using the NextToken parameter.
+     */
+    ListFinancialEventsByNextToken: function() {
+        return new FinancesRequest('ListFinancialEventsByNextToken', {
+            NextToken: { name: 'NextToken', required: true }
+        });
+    }
+};

--- a/lib/mws.js
+++ b/lib/mws.js
@@ -414,6 +414,7 @@ exports.ComplexList = ComplexListType;
 exports.Fbs = require('./fba');
 exports.Fba = require('./fba');
 exports.Orders = require('./orders');
+exports.Finances = require('./finances');
 exports.Sellers = require('./sellers');
 exports.Feeds = require('./feeds');
 exports.Products = require('./products');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Alex I. Vedmedenko",
       "email": "vedmalex@gmail.com"
+    },
+    {
+      "name": "PHaroZ",
+      "email": "github@pharoz.net"
     }
   ],
   "main": "./lib/mws",


### PR DESCRIPTION
Hi,

Currently the [Finances](http://docs.developer.amazonservices.com/en_US/finances/Finances_Overview.html) endpoints are not accessible through mws-sdk

This pull request aims to fix that. Added code came from https://github.com/kjdElectronics/mws-sdk .