### PR TITLE
Configurable content type for the request.

### DIFF
--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -107,6 +107,7 @@ var calls = exports.requests = {
       {
         FeedContents: { name: '_BODY_', required: true },
         FeedType: { name: 'FeedType', required: true },
+        FeedContentType: { name: '_FORMAT_', required: false },
         MarketplaceIds: { name: 'MarketplaceIdList.Id', list: true, required: false },
         PurgeAndReplace: { name: 'PurgeAndReplace', required: false, type: 'Boolean' }
       }, true);

--- a/lib/mws.js
+++ b/lib/mws.js
@@ -55,7 +55,7 @@ AmazonMwsClient.prototype.call = function (api, action, query) {
   // Check if we're dealing with a file (such as a feed) upload
   if (api.upload) {
     requestOpts.body = query._BODY_;
-    query._FORMAT_ = 'application/x-www-form-urlencoded';
+    query._FORMAT_ = query._FORMAT_ || 'application/x-www-form-urlencoded';
     requestOpts.headers = {
       'Content-Type': query._FORMAT_,
       'Content-MD5': crypto.createHash('md5').update(query._BODY_).digest('base64')


### PR DESCRIPTION
Amazon didn't check content type for a while.
At some point it started to require the value to be "x-www-form-urlencoded" exactly.
Later they reverted their changes.

We need a way to change the content type as needed externally.